### PR TITLE
Add datablitz to website

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -14,6 +14,8 @@ website:
         href: conf2024.qmd
       - text: "2024 Speakers"
         href: speakers2024.qmd
+      - text: "2024 Data Blitz"
+        href: datablitz2024.qmd
       - text: "Meeting Archive"
         href: archive.qmd
       - text: "Datathon Workshop"

--- a/conf2024.qmd
+++ b/conf2024.qmd
@@ -16,7 +16,7 @@ editor: visual
 :::
 
 | Time               | Session                    | Title | Speaker(s) | Location           |
-|------------|---------------------|---------------|---------------|----------|
+|--------------|-----------------|--------------|--------------|--------------|
 | 8:30am - 9:00am    | Opening                    |       |            | In person & online |
 | 9:00am - 9:45am    | Morning Keynote            | TBD   | TBD        | In person & online |
 | 9:50am - 10:05am   | Morning Talks              | TBD   | TBD        | In person & online |

--- a/datablitz2024.qmd
+++ b/datablitz2024.qmd
@@ -1,0 +1,19 @@
+---
+toc: false
+format: html
+editor: visual
+---
+
+#### 🗓️ Date 3/29/24
+
+#### ⏰ Time  10:50-11 a.m.
+
+\
+
+The WIDS Tucson Data Blitz sessions will be *short* (3-minute) talks from members of the WIDS community. A slide template will be provided - you just need to tell us about your exciting work! 
+
+We will have a morning session and, if needed, an additional afternoon session.
+
+::: callout-important
+## [Interested in presenting? Sign up here before March 8!](https://forms.gle/tPX64pkdqYawKZEV8)
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -21,4 +21,6 @@ WiDS Tucson is independently organized by the University of Arizona to be part o
 
 The purpose of the WiDS conference is to inspire and educate data scientists worldwide, regardless of gender, and to support women in the field. This one-day technical conference provides an opportunity to hear about the latest data science related research and applications in a number of domains, and connect with others in the field.
 
-[Register for the Event!](https://forms.gle/ttzf3MyogJuCNAeD9){target="_blank"}
+[Register to attend the Event!](https://forms.gle/ttzf3MyogJuCNAeD9){target="_blank"}
+
+[Sign up to present at the Data Blitz!](https://forms.gle/gsJPpNThczgRnUE66){target="_blank"} _Sign-up deadline: March 8, 2024._


### PR DESCRIPTION
This adds a page for the Data Blitz to the website and links to the application form from the front page.